### PR TITLE
vendor type was not saving when creating a new vendor. checked edit v…

### DIFF
--- a/BackendCapstone/Services/VendorsRepository.cs
+++ b/BackendCapstone/Services/VendorsRepository.cs
@@ -66,12 +66,14 @@ namespace BackendCapstone.Services
                                                  ([Name]
                                                  ,[PhoneNumber]
                                                  ,[ContactName]
-                                                 ,[FieldOfWork])
+                                                 ,[FieldOfWork]
+                                                 ,[VendorTypeId])
                                             VALUES
                                                  (@Name
                                                  ,@PhoneNumber
                                                  ,@ContactName
-                                                 ,@FieldOfWork)", vendor);
+                                                 ,@FieldOfWork
+                                                 ,@VendorTypeId)", vendor);
                 return records == 1;
             }
         }


### PR DESCRIPTION
…endor and vendor type was saving when editing a vendor. found that VendorTypeId was not being saved to the database. added VendorTypeId as a field that needed to be saved when creating a vendor in the VendorsRepository. vendor type is now saving when creating a new vendor.